### PR TITLE
Fixed typographical error, changed availabe to available in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ Building upon developments in theoretical and applied machine learning, as well 
 The source and data in this repository allow for the reproduction of the results in this paper.  
 
 ## Data Description
-The data used in this paper is availabe from the [Supreme Court Database (SCDB)](http://scdb.wustl.edu/).
+The data used in this paper is available from the [Supreme Court Database (SCDB)](http://scdb.wustl.edu/).


### PR DESCRIPTION
mjbommar, I've corrected a typographical error in the documentation of the [scotus-predict](https://github.com/mjbommar/scotus-predict) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
